### PR TITLE
update dependencies & fix Buffer() deprecation

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 # History
 
-## v 0.4.5 (January 13, 2021)
+## v 0.4.5 (January 13, 2022)
 * Updated dependencies.
 * Fixed Buffer deprecation warnings.
 

--- a/History.md
+++ b/History.md
@@ -1,5 +1,9 @@
 # History
 
+## v 0.4.5 (January 13, 2021)
+* Updated dependencies.
+* Fixed Buffer deprecation warnings.
+
 ## v 0.4.4 (September 26, 2017)
 * Extraneous files removed from NPM package.
 * Improved package keywords and added license.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2017 Talha Asad
+Copyright (c) 2014 - 2022 Talha Asad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Readme.md
+++ b/Readme.md
@@ -174,7 +174,7 @@ uploader.begin(); // important if callback not provided.
 
 The MIT License (MIT)
 
-Copyright (c) 2014 - 2017 Talha Asad
+Copyright (c) 2014 - 2022 Talha Asad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function StreamingS3(stream, s3AccessKey, s3SecretKey, s3Params, options, cb) {
   this.totalBytes = 0;
   
   // Chunking and buffering
-  this.buffer = new Buffer(0);
+  this.buffer = Buffer.alloc(0);
   this.chunks = [];
   this.chunkNumber = 0;
   this.totalChunks = 0;
@@ -146,7 +146,7 @@ StreamingS3.prototype.begin = function() {
   this.streamDataHandler = function(chunk) {
     self.reading = true;
     if (!self.downloadStart) self.downloadStart = Date.now();
-    if (typeof chunk === 'string') chunk = new Buffer(chunk, 'utf-8');
+    if (typeof chunk === 'string') chunk = Buffer.from(chunk, 'utf-8');
     self.totalBytes += chunk.length;
     self.buffer = Buffer.concat([self.buffer, chunk]);
     self.emit('data', chunk.length);
@@ -193,10 +193,10 @@ StreamingS3.prototype.flushChunk = function() {
   var newChunk;
   if (this.buffer.length > this.options.maxPartSize) {
     newChunk = this.buffer.slice(0, this.options.maxPartSize);
-    this.buffer = new Buffer(this.buffer.slice(this.options.maxPartSize));
+    this.buffer = Buffer.from(this.buffer.slice(this.options.maxPartSize));
   } else {
     newChunk = this.buffer.slice(0, this.options.maxPartSize);
-    this.buffer = new Buffer(0);
+    this.buffer = Buffer.alloc(0);
   }
     
   // Add useful properties to each chunk.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "name": "streaming-s3",
   "description": "Streaming uploads to Amazon Web Service (AWS) S3 for NodeJS",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "keywords": [
     "aws s3",
     "aws s3 streaming",
@@ -22,7 +22,7 @@
     "streaming upload",
     "s3 streaming upload"
   ],
-  "license" : "MIT",
+  "license": "MIT",
   "homepage": "http://fallentech.github.io/streaming-s3",
   "repository": {
     "type": "git",
@@ -33,8 +33,8 @@
     "node": ">=0.10.0"
   },
   "dependencies": {
-    "async": "2.5.0",
-    "aws-sdk": "2.122.0",
+    "async": "^3.0.0",
+    "aws-sdk": "^2.814.0",
     "request": "^2.82.0"
   }
 }


### PR DESCRIPTION
## Dependency Updates
* removed exact version requirements which will help negate package duplication in `node_modules`
* updated `async` to the latest major version
* updated `aws-sdk` to allow for any version greater than or equal to `2.814.0` as previous minor versions suffered from vulnerabilities

## Deprecation warnings
* fixed Buffer() deprecation warning according to [this guide](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/) by nodejs.

## Resolved Issues
* doesn't resolve #6 but goes give users more options
* fixes issue #20 
* fixes issue #21 